### PR TITLE
Adx 458 update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,26 @@ jobs:
       python: "2.7"
       env: CKANVERSION=2.9
       services:
-          - postgresql
           - redis
           - docker
+      addons:
+        postgresql: "12.4"
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
+          packages:
+            - postgresql-12.4
 
     - python: "3.6"
       env: CKANVERSION=2.9
+      addons:
+        postgresql: "12.4"
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
+          packages:
+            - postgresql-12.4
+
       services:
           - postgresql
           - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,31 +39,21 @@ jobs:
     - stage: Tests
       python: "2.7"
       env: CKANVERSION=2.9
-      services:
-          - redis
-          - docker
       addons:
-        postgresql: "12.4"
+        postgresql: '12'
         apt:
-          sources:
-            - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
           packages:
-            - postgresql-12.4
+            - postgresql-12
+            - postgresql-client-12
 
     - python: "3.6"
       env: CKANVERSION=2.9
       addons:
-        postgresql: "12.4"
+        postgresql: '12'
         apt:
-          sources:
-            - sourceline: 'deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main'
           packages:
-            - postgresql-12.4
-
-      services:
-          - postgresql
-          - redis
-          - docker
+            - postgresql-12
+            - postgresql-client-12
 
     - python: "2.7"
       env: CKANVERSION=2.8


### PR DESCRIPTION
A major version update of postgres from 12 to 13 took place and caused our build process to break.  Here I'm fixing our postgres version in travis builds.  

The problem occurred with the pg_lsclusters command in the build script. 

Since we are fixing our other dependencies, I'm assuming fixing the postgres version is a good thing?  The other root could be to fix the build script for postgres 13...