### PR TITLE
Minified logging info for failed get_user helper. Added context for '…

### DIFF
--- a/ckanext/scheming/unaids_helpers.py
+++ b/ckanext/scheming/unaids_helpers.py
@@ -5,6 +5,8 @@ import logging
 import ckanext.scheming.helpers as helpers
 from ckanapi import NotFound
 from ckan.plugins.toolkit import get_action
+import ckan.model as model
+from ckan.common import g
 
 
 @helpers.helper
@@ -20,11 +22,12 @@ def get_user(user_id):
     """
     Returns the user object for a given user_id.
     """
+    context = {'model': model, 'user': g.user}
     try:
-        result = get_action('user_show')({}, {'id': user_id})
+        result = get_action('user_show')(context, {'id': user_id})
         return result
-    except Exception as e:
-        logging.exception(e)
+    except Exception:
+        logging.warning("Failed to get user dict for user_id: {}".format(user_id))
         return {}
 
 


### PR DESCRIPTION
…user_show' action.

While browsing CloudWatch logs I've found many entries like:
`
2020-11-10 17:30:40,774 ERROR [root]
--
Traceback (most recent call last):
File "/usr/lib/ckan/venv/src/ckanext-scheming/ckanext/scheming/unaids_helpers.py", line 24, in get_user
result = get_action('user_show')({}, {'id': user_id})
File "./ckan/logic/__init__.py", line 473, in wrapped
result = _action(context, data_dict, **kw)
File "./ckan/logic/action/get.py", line 1418, in user_show
_check_access('user_show', context, data_dict)
File "./ckan/logic/__init__.py", line 313, in check_access
raise NotAuthorized(msg)
NotAuthorized
`

I have decided to:
1. Change the way we log info about such an event (we don't need stack trace for this)
2. Call the "user_show" action inside the helper with a context. Current user `g.user` should be there as "user_show" includes some sensitive information if called by the user itself or admin (full e-mail instead of hash, api ket etc.)
3. I have also added model to the context. I don't know if it's needed or not but that's the way I've found "user_show" called in other places in ckan codebase.
 

