### PR TITLE
Fix external dependency in test data.

### DIFF
--- a/ckanext/scheming/tests/test_load.py
+++ b/ckanext/scheming/tests/test_load.py
@@ -16,8 +16,8 @@ class TestLoadSchema(object):
     def test_url_to_schema(self):
         assert (
             _load_schema(
-                "https://raw.githubusercontent.com/ckan/ckanext-scheming/"
-                "master/ckanext/scheming/camel_photos.json"
+                "https://raw.githubusercontent.com/fjelltopp/ckanext-scheming/"
+                "development/ckanext/scheming/camel_photos.json"
             )["dataset_type"]
             == "camel-photos"
         )


### PR DESCRIPTION
https://raw.githubusercontent.com/fjelltopp/ckanext-scheming/master/ckanext/scheming/camel_photos.json has been replaced by a yml file in original fork master branch. Our tests should be using the raw file from our repo.
This test is still not good though. This PR is just a quick fix. Ideally the file should be served via some stub http local test server.