### PR TITLE
ADX-738 api uploads

### DIFF
--- a/ckanext/scheming/plugins.py
+++ b/ckanext/scheming/plugins.py
@@ -151,7 +151,8 @@ class _SchemingMixin(object):
             'autogenerate': unaids_validators.autogenerate,
             'unique_combination': unaids_validators.unique_combination,
             'auto_create_valid_name': unaids_validators.auto_create_valid_name,
-            'scheming_shapefile': unaids_validators.scheming_shapefile
+            'scheming_shapefile': unaids_validators.scheming_shapefile,
+            'autofill': unaids_validators.autofill
         }
 
     @run_once_for_caller('_scheming_add_template_directory', lambda: None)

--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -150,7 +150,8 @@
     {
       "preset_name": "hidden_value",
       "values": {
-        "form_snippet": "hidden_fields.html"
+        "form_snippet": "hidden_fields.html",
+        "validators": "autofill"
       }
     },
     {

--- a/ckanext/scheming/tests/schemas/autofill_validator.json
+++ b/ckanext/scheming/tests/schemas/autofill_validator.json
@@ -1,0 +1,44 @@
+{
+    "scheming_version": 1,
+    "dataset_type": "autofill-validator",
+    "name": "Auto create valid name",
+    "link_name": "Auto create valid name",
+    "about": "",
+    "about_url": "http://github.com/ckan/ckanext-scheming",
+    "add_data_on_create": false,
+    "dataset_fields": [{
+            "field_name": "title",
+            "label": "Title:",
+            "form_snippet": "text.html",
+            "classes": ["hidden"]
+        },
+        {
+            "field_name": "name",
+            "label": "URL",
+            "form_snippet": "text.html",
+            "validators": "auto_create_valid_name not_empty unicode name_validator package_name_validator",
+            "classes": ["hidden"]
+        },
+        {
+            "label": "Location",
+            "field_name": "location"
+        },
+        {
+            "label": "Year",
+            "field_name": "year",
+            "validators": "autofill"
+        },
+        {
+            "label": "Schema",
+            "field_name": "schema",
+            "field_value": "art_3",
+            "validators": "autofill"
+        },
+        {
+            "label": "Type",
+            "field_name": "dataset_type",
+            "default": "data-type",
+            "validators": "autofill"
+        }
+    ]
+}

--- a/ckanext/scheming/tests/test_unaids_validators.py
+++ b/ckanext/scheming/tests/test_unaids_validators.py
@@ -41,3 +41,26 @@ class TestAutoCreateValidName(object):
             type="auto-create-valid-name", year="2020", location="north-pole"
         )
         assert dataset3['name'] == u'north-pole-autogenerate-2020-1'
+
+
+@pytest.mark.usefixtures(u'clean_db')
+@pytest.mark.usefixtures(u'clean_index')
+class TestAutofill(object):
+    def test_autofilling(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type="autofill-validator", title="AutoFill", name='autofill', location="north-pole"
+        )
+        assert dataset['schema'] == u'art_3'
+        assert dataset['dataset_type'] == u'data-type'
+        assert dataset['year'] == u''
+
+    def test_not_overwriting(self):
+        lc = LocalCKAN()
+        dataset = lc.action.package_create(
+            type="autofill-validator", title="AutoFill", name='autofill', location="north-pole",
+            schema="art_4", dataset_type="different-data-type", year="1984"
+        )
+        assert dataset['schema'] == u'art_4'
+        assert dataset['dataset_type'] == u'different-data-type'
+        assert dataset['year'] == u'1984'

--- a/ckanext/scheming/unaids_validators.py
+++ b/ckanext/scheming/unaids_validators.py
@@ -109,6 +109,17 @@ def autogenerate(field, schema):
     return validator
 
 
+@scheming_validator
+def autofill(field, schema):
+    field_value = field.get(u'field_value', field.get('default', ''))
+
+    def validator(key, data, errors, context):
+        if not data.get(key):
+            data[key] = field_value
+
+    return validator
+
+
 def __lower_formatter(input):
     return input.lower()
 

--- a/test.ini
+++ b/test.ini
@@ -17,6 +17,7 @@ scheming.dataset_schemas = ckanext.scheming:ckan_dataset.json
                            ckanext.scheming.tests:test_schema.json
                            ckanext.scheming.tests:test_datastore_choices.json
                            ckanext.scheming.tests.schemas:auto_unique_validator.json
+                           ckanext.scheming.tests.schemas:autofill_validator.json
 scheming.organization_schemas = ckanext.scheming:org_with_dept_id.json
                                 ckanext.scheming:custom_org_with_address.json
 scheming.group_schemas = ckanext.scheming:group_with_bookface.json


### PR DESCRIPTION
Create a validator that will auto populate a value in the dataset with a hard coded value from the schema. This solves the problem of the bulk file uploader not triggering validation and also significantly improves the experience working with the api and schemed packages. 