### PR TITLE
Fix github actions.

### DIFF
--- a/ckanext/scheming/tests/test_group_display.py
+++ b/ckanext/scheming/tests/test_group_display.py
@@ -16,7 +16,7 @@ class TestOrganizationDisplay(object):
 class TestGroupDisplay(object):
     def test_group_displays_custom_fields(self, app):
         user = Sysadmin()
-        Group(user=user, name="group-one", bookface="theoneandonly")
+        Group(user=user, name="group-one", bookface="theoneandonly", type='group')
 
         response = app.get("/group/about/group-one")
         assert "Bookface" in response.body


### PR DESCRIPTION
Supplying a group type fixes the breaking test.  I don't believe the test is actually testing whether a group should be creatable without specifying a group test so I don't believe we are "breaking" the intended purpose of the test in any way.  Either way we arn't really using groups in the ADR.  So this small fix seems the best way to getting back on track with requiring the github action prior to merging scheming plugins. 