### PR TITLE
ADX-1086 VMMC resources only for selected countries ADX-1087 Add Zanzibar (autonomous island in Tanzania) as location option for datasets metadata

### DIFF
--- a/ckanext/scheming/unaids_helpers.py
+++ b/ckanext/scheming/unaids_helpers.py
@@ -51,6 +51,7 @@ def get_missing_resources(pkg, schema):
 
     return ret
 
+
 def include_vmmc_resources(pkg, resource_type):
     vmmc_countries = [
         "Botswana",
@@ -76,6 +77,7 @@ def include_vmmc_resources(pkg, resource_type):
     else:
         return True
 
+
 @helpers.helper
 def scheming_country_list():
     """
@@ -87,6 +89,10 @@ def scheming_country_list():
             "text": country.name,
             "value": country.name
         })
+    countries.append({
+        "text": "Zanzibar",
+        "value": "Zanzibar"
+    })
     return sorted(countries, key=lambda k: k['value'])
 
 

--- a/ckanext/scheming/unaids_helpers.py
+++ b/ckanext/scheming/unaids_helpers.py
@@ -44,11 +44,37 @@ def get_missing_resources(pkg, schema):
 
     ret = []
     for r in schema.get('resources', []):
-        if r['resource_type'] not in pkg_res:
-            ret.append(r)
+        resource_type_ = r['resource_type']
+        if resource_type_ not in pkg_res:
+            if include_vmmc_resources(pkg, resource_type_):
+                ret.append(r)
 
     return ret
 
+def include_vmmc_resources(pkg, resource_type):
+    vmmc_countries = [
+        "Botswana",
+        "Eswatini",
+        "Ethiopia",
+        "Kenya",
+        "Lesotho",
+        "Malawi",
+        "Mozambique",
+        "Namibia",
+        "Rwanda",
+        "South Africa",
+        "South Sudan",
+        "Tanzania",
+        "Uganda",
+        "Zambia",
+        "Zimbabwe"
+    ]
+    vmmc_resource_types = ['inputs-unaids-vmmc-coverage-inputs', 'inputs-unaids-vmmc-coverage-outputs']
+    country_ = pkg.get('geo-location')
+    if resource_type in vmmc_resource_types and country_ not in vmmc_countries:
+        return False
+    else:
+        return True
 
 @helpers.helper
 def scheming_country_list():


### PR DESCRIPTION
## Description

ADX-1086
VMMC resources should be displayed as missing resources only for a specific set of countries. I've decided to inline the location list inside the helper function for the sake of simplicity. My other idea of putting it as a part of the ini file would cause a drift of settings with every change (which might be quite often) with adx_deploy & adx_develop.

ADX-1087
Add Zanzibar (autonomous island in Tanzania) as location option for datasets metadata. This required a custom handling of this "dummy" country in the SVG map location blueprint for the map on the ADR homepage.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
