### PR TITLE
Fix resource list nesting from markdown 'about' fields

### DIFF
--- a/ckanext/scheming/templates/scheming/package/snippets/autogenerated_resource_item.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/autogenerated_resource_item.html
@@ -17,7 +17,7 @@
   {% block resource_item_description %}
     <p class="description">
       {% if res.about %}
-        {{ h.markdown_extract(h.get_translated(res, 'about'), extract_length=80) }}
+        {{ h.render_markdown(h.get_translated(res, 'about')) | striptags | truncate(80) }}
       {% endif %}
     </p>
   {% endblock %}

--- a/ckanext/scheming/templates/scheming/package/snippets/missing_resource_item.html
+++ b/ckanext/scheming/templates/scheming/package/snippets/missing_resource_item.html
@@ -13,7 +13,7 @@
   {% block resource_item_description %}
     <p class="description">
       {% if res.about %}
-        {{ h.markdown_extract(h.get_translated(res, 'about'), extract_length=80) }}
+        {{ h.render_markdown(h.get_translated(res, 'about')) | striptags | truncate(80) }}
       {% endif %}
     </p>
   {% endblock %}


### PR DESCRIPTION
## Problem

Same stored HTML-structure issue as the core resource list, but for the **Missing Resources** and **Autogenerated Resources** snippets, which render the schema-defined **`about`** field.

`markdown_extract` renders `about` to HTML then truncates the HTML string; bleach keeps `<ul>/<li>`, so a bulleted `about` can be cut mid-tag into an unclosed `<ul>`. As these render as sibling `<li class="resource-item">` in a shared `<ul class="resource-list">`, the browser nests every following resource under the offending one.

## Fix

In `missing_resource_item.html` and `autogenerated_resource_item.html`:

```diff
- {{ h.markdown_extract(h.get_translated(res, 'about'), extract_length=80) }}
+ {{ h.render_markdown(h.get_translated(res, 'about')) | striptags | truncate(80) }}
```

Render markdown, strip all tags, then truncate the plain text — no unbalanced HTML possible. XSS-safe (plain string is auto-escaped by Jinja).

Before:
<img width="896" height="464" alt="image" src="https://github.com/user-attachments/assets/52c0c453-8ef5-4bf7-8511-378d321d0eff" />

After:
<img width="896" height="464" alt="image" src="https://github.com/user-attachments/assets/27c0fa18-804e-41d5-8601-9ca66843e938" />


## Verification

Reproduced locally by giving a missing resource's schema `about` a markdown bullet list: the following missing resources nested (1 top-level, 5 nested). After the fix the section is flat (6 top-level, 0 nested).
